### PR TITLE
fix project name, add new ignore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 /Debug
+Src/Backup/*
+Inc/Backup/*
+.mxproject
+
 # Prerequisites
 *.d
 

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>ITMO_cLAB_Template</name>
+	<name>SDK_cLAB</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
После коммита `Заменен .ioc файл`(https://github.com/lmtspbru/SDK_cLAB/commit/1a92b463aeaecaa4f1df6d92b517918c8c462ada) CubeIde больше не может открыть CubeMX конфигуратор, т.к. само имя проекта не было изменено:
![stm32cubeide_IIu9l2dhGu](https://user-images.githubusercontent.com/38138387/96364300-ae9d7300-1142-11eb-971f-87456dbbec66.png)
 Поправлено. Добавлен игнор некоторых не нужных файлов.